### PR TITLE
Fix for failing from command in ZSH

### DIFF
--- a/extraterm/src/commands/setup_extraterm_zsh.zsh
+++ b/extraterm/src/commands/setup_extraterm_zsh.zsh
@@ -12,7 +12,7 @@ if [ -n "$LC_EXTRATERM_COOKIE" ]; then
 
     # Put our enhanced commands at the start of the PATH.
     filedir=`dirname "${(%):-%x}"`
-    export PATH="$PWD/$filedir:$PATH"
+    export PATH="$filedir:$PATH"
 
     # Insert our special code to communicate to Extraterm the status of the last command.
     extraterm_install_prompt_integration () {


### PR DESCRIPTION
Calling `from` produced `zsh: command not found: exfrom.py` error.

After investingating `PATH` it appears that path began with `/home/user//home/user/.extraterm-commands:` instead of `/home/user/.extraterm-commands:`. Removing `$PWD/` fixed that.