### PR TITLE
Fix bug that allows unix arguments to work + small amount of cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ packages/extraterm-shell-string-parser/main.d.ts
 packages/extraterm-shell-string-parser/test/MainTest.d.ts
 
 
+packages/extraterm-readonly-toolbox/test/MainTest.d.ts
+packages/extraterm-web-component-decorators/test/DecoratorsTest.d.ts
+packages/extraterm-web-component-decorators/test/TestCode.d.ts

--- a/extensions/UnixSessionEditor/src/UnixSessionEditorExtension.ts
+++ b/extensions/UnixSessionEditor/src/UnixSessionEditorExtension.ts
@@ -73,7 +73,7 @@ export function activate(context: ExtensionContext): any {
         name: this._ui.name,
         useDefaultShell: this._ui.useDefaultShell === 1,
         shell: this._ui.shell,
-        args: this._ui.args,
+        args: this._ui.args
       };
       this._checkShellPath();
       this.updateSessionConfiguration(changes);

--- a/extensions/UnixSessionEditor/src/UnixSessionEditorUi.ts
+++ b/extensions/UnixSessionEditor/src/UnixSessionEditorUi.ts
@@ -36,8 +36,9 @@ import Vue from 'vue';
       </datalist>
     </div>
   </div>
+
   <div class="form-group">
-    <label for="name" class="col-sm-4 control-label">Arguments:</label>
+    <label for="args" class="col-sm-4 control-label">Arguments:</label>
     <div class="input-group col-sm-8">
       <input type="text" class="form-control" name="args" v-model="args">
     </div>
@@ -51,5 +52,5 @@ export class UnixSessionEditorUi extends Vue {
   useDefaultShell: number = 1;
   shellErrorMsg = "";
   etcShells: string[] = [];
-  args: string;
+  args: string = "";
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "run": "electron extraterm/src/main_process/Main.js --dev-tools",
+    "run-release": "electron extraterm/src/main_process/Main.js",
     "build": "wsrun build --exclude-missing --stages",
     "electron-rebuild": "node ./node_modules/electron-rebuild/lib/src/cli.js -o node-pty,font-manager -f -v 2.0.0",
     "package": "node build_scripts/build_packages.js"


### PR DESCRIPTION
There was a small bug in the HTML as well as the argument initialization that prevented arguments from working.  That is now fixed and has been tested using Linux.  My test was was default shell with the following options being passed in: -c top, which resulted in what was expected. 

I also added a few files to .gitignore as they looked to be missing, as well as a new run script that launches extraterm without development console showing. 