### PR TITLE
Early-out from setup_extraterm_bash.sh if aliases already setup (avoi…

### DIFF
--- a/extraterm/src/commands/setup_extraterm_bash.sh
+++ b/extraterm/src/commands/setup_extraterm_bash.sh
@@ -5,6 +5,7 @@
 # This source code is licensed under the MIT license which is detailed in the LICENSE.txt file.
 # 
 
+if [ -z "`alias | grep from`" ]; then
 if [ -n "$LC_EXTRATERM_COOKIE" ]; then
     echo "Setting up Extraterm support."
 
@@ -47,4 +48,5 @@ if [ -n "$LC_EXTRATERM_COOKIE" ]; then
         alias from="exfrom.py"
         alias show="exshow.py"
     fi
+fi
 fi

--- a/extraterm/src/commands/setup_extraterm_bash.sh
+++ b/extraterm/src/commands/setup_extraterm_bash.sh
@@ -1,52 +1,62 @@
 # This file should be sourced from your .bashrc file.
 #
-# Copyright 2014-2016 Simon Edwards <simon@simonzone.com>
+# Copyright 2014-2018 Simon Edwards <simon@simonzone.com>
 #
 # This source code is licensed under the MIT license which is detailed in the LICENSE.txt file.
 # 
 
-if [ -z "`alias | grep from`" ]; then
-if [ -n "$LC_EXTRATERM_COOKIE" ]; then
-    echo "Setting up Extraterm support."
+# Early-out in case this has been sourced and enabled already
+# https://github.com/sedwards2009/extraterm/pull/148
 
-    # Put our enhanced commands at the start of the PATH.
-    filedir=`dirname "$BASH_SOURCE"`
-    if [ ${filedir:0:1} != "/" ]
-    then
-        filedir="$PWD/$filedir"
-    fi
-    
-    export PATH="$filedir:$PATH"
+isfunction () {
+    type $1 2> /dev/null | head -n1 | grep "$1 is a function" > /dev/null
+}
 
-    PREVIOUS_PROMPT_COMMAND=$PROMPT_COMMAND
-    postexec () {
-      echo -n -e "\033&${LC_EXTRATERM_COOKIE};3\007"
-      echo -n $1
-      echo -n -e "\000"
-      $PREVIOUS_PROMPT_COMMAND
-    }
-    export PROMPT_COMMAND="postexec \$?"
+if ( isfunction "postexec"            ); then return 0; fi
+if ( isfunction "preexec"             ); then return 0; fi
+if ( isfunction "preexec_invoke_exec" ); then return 0; fi
 
-    preexec () {
-        echo -n -e "\033&${LC_EXTRATERM_COOKIE};2;bash\007"
-        echo -n $1
-        echo -n -e "\000"
-    }
+# Early-out if LC_EXTRATERM_COOKIE is not set
+if [ -z "$LC_EXTRATERM_COOKIE" ]; then return 0; fi
 
-    preexec_invoke_exec () {
-        [ -n "$COMP_LINE" ] && return                     # do nothing if completing
-        [ "$BASH_COMMAND" = "$PROMPT_COMMAND" ] && return # don't cause a preexec for $PROMPT_COMMAND
-        local this_command=`history 1`; # obtain the command from the history
-        preexec "$this_command"
-    }
-    trap 'preexec_invoke_exec' DEBUG
+echo "Setting up Extraterm support."
 
-    # Look for Python 3 support.
-    if ! which python3 > /dev/null; then
-        echo "Unable to find the Python3 executable!"
-    else
-        alias from="exfrom.py"
-        alias show="exshow.py"
-    fi
+# Put our enhanced commands at the start of the PATH.
+filedir=`dirname "$BASH_SOURCE"`
+if [ ${filedir:0:1} != "/" ]
+then
+    filedir="$PWD/$filedir"
 fi
+
+export PATH="$filedir:$PATH"
+
+PREVIOUS_PROMPT_COMMAND=$PROMPT_COMMAND
+postexec () {
+  echo -n -e "\033&${LC_EXTRATERM_COOKIE};3\007"
+  echo -n $1
+  echo -n -e "\000"
+  $PREVIOUS_PROMPT_COMMAND
+}
+export PROMPT_COMMAND="postexec \$?"
+
+preexec () {
+    echo -n -e "\033&${LC_EXTRATERM_COOKIE};2;bash\007"
+    echo -n $1
+    echo -n -e "\000"
+}
+
+preexec_invoke_exec () {
+    [ -n "$COMP_LINE" ] && return                     # do nothing if completing
+    [ "$BASH_COMMAND" = "$PROMPT_COMMAND" ] && return # don't cause a preexec for $PROMPT_COMMAND
+    local this_command=`history 1`; # obtain the command from the history
+    preexec "$this_command"
+}
+trap 'preexec_invoke_exec' DEBUG
+
+# Look for Python 3 support.
+if ! which python3 > /dev/null; then
+    echo "Unable to find the Python3 executable!"
+else
+    alias from="exfrom.py"
+    alias show="exshow.py"
 fi


### PR DESCRIPTION
I have a habit of re-sourcing my `.bashrc` from time to time.

However, `setup_extraterm_bash.sh` gets stuck if it's re-sourced.

This is a nasty workaround to early-out if the from alias is already set.