### PR TITLE
Fixes #294: Tab completion repeats the first character (oh-my-zsh)

### DIFF
--- a/extraterm/src/commands/setup_extraterm_zsh.zsh
+++ b/extraterm/src/commands/setup_extraterm_zsh.zsh
@@ -32,7 +32,7 @@ extraterm_install_prompt_integration () {
     
     if [[ ! "$PS1" =~ "$LC_EXTRATERM_COOKIE" ]] ; then
         prefix=`echo -n -e "%{\0033&${LC_EXTRATERM_COOKIE};3\0007%}%?%{\0000%}"`
-        export PS1="${prefix}${PS1}"
+        export PS1="%{${prefix}%}${PS1}"
     fi
 }
 extraterm_install_prompt_integration


### PR DESCRIPTION
Fixes #294 

To test:

Using oh-my-zsh with the Extraterm setup injected into the session, (e.g., Agnoster theme; although theme is not a factor):

## Before PR:

1. Open a terminal and carry out tab-completion on, say, the letter `c`
2. Notice that the `c` character is repeated.

## After PR:

Notice that the `c` character is not repeated.