### PR TITLE
Fix Python Regexp for Cygwin

### DIFF
--- a/extensions/ProxySessionBackend/src/CygwinProxySessionBackend.ts
+++ b/extensions/ProxySessionBackend/src/CygwinProxySessionBackend.ts
@@ -131,7 +131,7 @@ export class CygwinProxySessionBackend implements SessionBackend {
     const binDir = path.join(cygwinDir, 'bin');
     this._log.info("Cygwin bin directory is ", binDir);
     if (fs.existsSync(binDir)) {
-      const pythonRegexp = /^python3.*m\.exe$/;
+      const pythonRegexp = /^python3.*\.exe$/;
       const binContents = fs.readdirSync(binDir);
       const pythons = binContents.filter( name => pythonRegexp.test(name) );
       return pythons.length !== 0 ? path.join(binDir,pythons[0]) : null;

--- a/extensions/ProxySessionEditor/src/CygwinProxySessionEditor.ts
+++ b/extensions/ProxySessionEditor/src/CygwinProxySessionEditor.ts
@@ -110,7 +110,7 @@ async function checkCygwinPath(dirPath: string): Promise<string> {
 
     const binDir = path.join(dirPath, 'bin');
     if (await fse.pathExists(binDir)) {
-      const pythonRegexp = /^python3.*m\.exe$/;
+      const pythonRegexp = /^python3.*\.exe$/;
       const binContents = await fse.readdir(binDir);
       const pythons = binContents.filter( name => pythonRegexp.test(name) );
       if (pythons.length === 0) {


### PR DESCRIPTION
I installed Extraterm 0.57 today, I opened it and got this error:

```
Unable to find a suitable python executable in cygwin installation
```

![error](https://user-images.githubusercontent.com/486818/104052749-38695380-51fb-11eb-8b19-e31d2f0003bf.png)

Same error in Settings panel:

![settings](https://user-images.githubusercontent.com/486818/104053034-a6157f80-51fb-11eb-84cb-251ce0715b36.png)

I have Python 3 installed in Cygwin so this error was a mistake.

![python3 files](https://user-images.githubusercontent.com/486818/104052940-82523980-51fb-11eb-9a51-97a24686c414.png)

Error is solved by removing `m` from the regex.

![no error](https://user-images.githubusercontent.com/486818/104054089-7ff0df00-51fd-11eb-9617-a53bc73d38f0.png)