### PR TITLE
Recognise "super" as modifier, not final key

### DIFF
--- a/main/src/settings/keybindings/KeyRecord.ts
+++ b/main/src/settings/keybindings/KeyRecord.ts
@@ -98,7 +98,9 @@ export class KeyRecord {
       Key.Key_Meta,
       Key.Key_Alt,
       Key.Key_AltGr,
-      Key.Key_CapsLock
+      Key.Key_CapsLock,
+      Key.Key_Super_L,
+      Key.Key_Super_R,
     ].includes(key);
   }
 }


### PR DESCRIPTION
This is what Linux sees when you press the cmd/windows key. 

There isn't a single key, but different ones for left and right.