### PR TITLE
Fix nil reference to blockFrame.getBlock()

### DIFF
--- a/main/src/terminal/Terminal.ts
+++ b/main/src/terminal/Terminal.ts
@@ -823,7 +823,9 @@ export class Terminal implements Tab, Disposable {
       disposableHolder.add(blockFrame.onPopOutClicked((frame) => this.#handleBlockPopOutClicked(frame)));
     }
     this.#blockFrames.push({ frame: blockFrame, disposableHolder });
-    blockFrame.getBlock().setParent(this);
+    if (blockFrame.getBlock()) {
+      blockFrame.getBlock().setParent(this);
+    }
     this.scrollArea.appendBlockFrame(blockFrame);
   }
 


### PR DESCRIPTION
fixes: #399

As outlined in the above issue, a nil deref is always encountered with attempting to call 'getBlock()' on the blockFrame instance in Terminal.appendBlockFrame function.

Checking it, and only calling "setParent" seems to clear the issue from my testing.

Blocks render correctly and the zsh integration now works.

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>